### PR TITLE
Set location list card img to flex shrink 0 for ie11

### DIFF
--- a/assets/scss/uams-supporting/locations-list.scss
+++ b/assets/scss/uams-supporting/locations-list.scss
@@ -12,6 +12,10 @@
                 @include media-breakpoint-up(sm) {
                 }
 
+                img {
+                    flex-shrink: 0;
+                }
+
                 .card-title {
                     @extend .h5;
                 }


### PR DESCRIPTION
width was 100% of container, but height was full native height