### PR TITLE
Set review card body to align-items stretch for IE11

### DIFF
--- a/assets/scss/uams-supporting/doctors-item.scss
+++ b/assets/scss/uams-supporting/doctors-item.scss
@@ -79,4 +79,12 @@
             }
         }
     }
+
+    .card-list {
+        .card {
+            .card-body {
+                align-items: stretch;
+            }
+        }
+    }
 }


### PR DESCRIPTION
All text was squished into one row of text